### PR TITLE
Add popup box with ID copy result

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
-FILES=manifest.json background.js options/* icons/* LICENSE
+FILES=manifest.json \
+popup/* options/* icons/* LICENSE
 
 XPI_NAME=copy-message-id@j.kahn.xpi
 

--- a/manifest.json
+++ b/manifest.json
@@ -12,12 +12,10 @@
 		"page": "options/options.html"
 	},
 	"permissions": ["storage", "messagesRead", "clipboardWrite"],
-	"background": {
-		"scripts": ["background.js"]
-	},
 	"message_display_action": {
 		"default_title": "Copy Message ID",
-		"default_icon": "icons/button.png"
+		"default_icon": "icons/button.png",
+		"default_popup": "popup/popup.html"
 	},
 	"version": "1.2.0"
 }

--- a/popup/popup.css
+++ b/popup/popup.css
@@ -1,0 +1,15 @@
+body {
+  width: auto;
+  height: auto;
+  white-space: nowrap;
+  background-color: #0198E1;
+  color: white;
+}
+
+.hidden {
+  display: none;
+}
+.error {
+  color: white;
+  font-weight: bold;
+}

--- a/popup/popup.html
+++ b/popup/popup.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+
+<head>
+  <meta charset="utf-8">
+  <link rel="stylesheet" href="popup.css"/>
+</head>
+
+
+<html>
+  <body>
+  <div id="popup-content">
+    <p id="message-id">Copied ID: </p>
+  </div>
+  <div id="error-content" class="hidden">
+    <p id="error-string" class="error">Failed to copy message ID: </p>
+  </div>
+  <script src="popup.js"></script>
+  </body>
+</html>


### PR DESCRIPTION
Resolves #7 and resolves #8 . Adds a fancy popup box that either contains the copied ID on success, or the error information on failure.
![copyMessageIDPopup](https://user-images.githubusercontent.com/3311849/82413085-c0b7a000-9a42-11ea-9a13-3a5cdf1177c0.png)
![copyMessageIDPopupError](https://user-images.githubusercontent.com/3311849/82413150-de850500-9a42-11ea-884b-5d6eae3826a5.png)
