### PR TITLE
Allow newlines

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -17,5 +17,5 @@
 		"default_icon": "icons/button.png",
 		"default_popup": "popup/popup.html"
 	},
-	"version": "1.3.1"
+	"version": "1.3.2"
 }

--- a/options/options.css
+++ b/options/options.css
@@ -9,8 +9,10 @@ body {
   margin-left: 1.0em;
 }
 
-input[type="text"] {
+textarea[type="text"] {
   margin: 0.5em;
   width: 450px;
-  height: 2.0em;
+  height: 1.5em;
+  resize: none;
+  overflow: hidden;
 }

--- a/options/options.html
+++ b/options/options.html
@@ -9,8 +9,10 @@
 <body>
   <form>
       <p>Optionally add a prefix and suffix before and after the ID on copy.</p>
-      <label class=textLabel>Prefix: <input id="prefix" type="text"/></label>
-      <label class=textLabel>Suffix: <input id="suffix" type="text"/></label>
+      <label class=textLabel>Prefix: </label>
+      <textarea id="prefix" type="text"></textarea>
+      <label class=textLabel>Suffix: </label>
+      <textarea id="suffix" type="text"> </textarea>
       <label>Include angle brackets (&lt;&gt;): <input id="copyBrackets" type="checkbox"/></label>
       <br>
       <label>URL Encode the Message ID: <input id="urlEncode" type="checkbox"/></label>

--- a/options/options.js
+++ b/options/options.js
@@ -5,6 +5,17 @@ const urlEncodeInput = document.querySelector("#urlEncode");
 const rawInput = document.querySelector("#raw");
 
 /*
+Set text boxes to automatically resize.
+*/
+function autoResize() {
+  this.style.height = "5px";
+  this.style.height = this.scrollHeight + "px";
+}
+
+prefixInput.addEventListener("input", autoResize, false);
+suffixInput.addEventListener("input", autoResize, false);
+
+/*
 Store the currently selected settings using browser.storage.local.
 */
 function storeSettings() {


### PR DESCRIPTION
Addresses #13. Replace the `input` type used for `prefix` and `suffix` with `textarea` to allow typing and saving new lines as well.