### PR TITLE
Add keyboard shortcut Ctrl+Alt+O to copy message ID

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-FILES=manifest.json \
+FILES=manifest.json background.js \
 popup/* options/* icons/* LICENSE
 
 XPI_NAME=copy-message-id@j.kahn.xpi

--- a/background.js
+++ b/background.js
@@ -1,0 +1,46 @@
+browser.commands.onCommand.addListener(async (command) => {
+	if (command !== "copy-message-id") {
+		return;
+	}
+
+	try {
+		let tabs = await browser.tabs.query({active: true, currentWindow: true});
+		if (tabs.length != 1) {
+			throw new Error("Expected a single selected tab (got " + tabs.length + ")");
+		}
+
+		let tabId = tabs[0].id;
+		let message = await browser.messageDisplay.getDisplayedMessage(tabId);
+		if (!message) {
+			throw new Error("No message selected");
+		}
+
+		var options = {
+			prefix: "",
+			suffix: "",
+			copyBrackets: false,
+			urlEncode: false,
+		};
+		let config = await browser.storage.local.get("copyID");
+		if (config.copyID) {
+			options = config.copyID;
+		}
+
+		let parts = await browser.messages.getFull(message.id);
+		let message_id = parts.headers["message-id"][0];
+
+		if (!options.copyBrackets &&
+				message_id[0] == '<' &&
+				message_id[message_id.length - 1] == '>') {
+			message_id = message_id.slice(1, -1);
+		}
+		if (options.urlEncode) {
+			message_id = encodeURIComponent(message_id);
+		}
+
+		let s = options.prefix + message_id + options.suffix;
+		await navigator.clipboard.writeText(s);
+	} catch (error) {
+		console.error("Copy Message ID shortcut failed: " + error.message);
+	}
+});

--- a/manifest.json
+++ b/manifest.json
@@ -17,5 +17,17 @@
 		"default_icon": "icons/button.png",
 		"default_popup": "popup/popup.html"
 	},
+	"commands": {
+		"copy-message-id": {
+			"suggested_key": {
+				"default": "Ctrl+Alt+O"
+			},
+			"description": "Copy Message ID"
+		}
+	},
+	"background": {
+		"scripts": ["background.js"],
+		"persistent": false
+	},
 	"version": "1.3.2"
 }


### PR DESCRIPTION
- Added a command that executes the copy message ID and setup a shortcut (default Ctrl+Alt+O) for it.
- The shortcut respects prefix/suffix/brackets/urlEncode settings.
- background.js is the listener for the command.
- Updated Makefile to include background.js in the XPI build.